### PR TITLE
Update Copilot instructions for blog repository

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,13 +1,25 @@
-# Repository rules for Copilot coding agent
+# Copilot instructions for this blog repository
 
-Work PR-first. Never attempt to change the default branch directly.
-Prefer small, reviewable changes over broad refactors.
-Run lint and tests before finishing work.
-If the request is ambiguous, choose the smallest safe implementation.
-Do not change auth, secrets, billing, CI, infra, or database schema unless the issue explicitly asks for it.
-When opening a PR, include:
-- what changed
-- why it changed
-- risks / edge cases
-- tests run
-- follow-up work not included
+This repository is a technical blog focused on enterprise AI, AI agents, AI architectures,
+reinforcement learning, human-in-the-loop systems, and AI safety.
+
+Core rules:
+- Never publish directly to the default branch.
+- Prefer small, reviewable pull requests.
+- Preserve the author's voice: architecture-first, practical, technical, non-hype.
+- Do not invent facts, sources, dates, quotes, or statistics.
+- If a post references current events, tools, research, or companies, leave TODO markers for verification if the issue does not provide sources.
+- Do not modify site-wide layout, theme, config, analytics, or deployment files unless explicitly asked.
+- Keep drafts structured, skimmable, and useful to senior engineers and architects.
+- When drafting a post, include:
+  - strong title
+  - thesis in opening paragraph
+  - clear section structure
+  - practical implications
+  - risks / limitations
+  - conclusion
+- When opening a PR, include:
+  - what draft or page was created/updated
+  - what assumptions were made
+  - where human fact-checking is still needed
+  - any suggested follow-up posts


### PR DESCRIPTION
Expanded guidelines for contributing to the blog repository, emphasizing structure and clarity in posts.