### PR TITLE
feat: add RSS feed, sitemap, Twitter cards, JSON-LD, and canonical URLs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,3 +58,35 @@ When opening a PR for a new post, include:
 - any internal links added or updated
 
 Do not leave the homepage stale after adding a live article.
+
+## SEO requirements for every page
+
+Every new blog post HTML must include these in `<head>`, after the `og:type` meta tag and before the Mailchimp script:
+
+1. Canonical URL:
+   `<link rel="canonical" href="https://ogkranthi.github.io/{filename}.html">`
+
+2. Twitter card meta tags:
+   ```html
+   <meta name="twitter:card" content="summary">
+   <meta name="twitter:site" content="@ogkranthi">
+   <meta name="twitter:title" content="{same as og:title}">
+   <meta name="twitter:description" content="{same as og:description}">
+   ```
+
+3. JSON-LD Article structured data:
+   ```html
+   <script type="application/ld+json">
+   {
+     "@context": "https://schema.org",
+     "@type": "Article",
+     "headline": "{article title}",
+     "description": "{meta description}",
+     "author": { "@type": "Person", "name": "Kranthi Manchikanti" },
+     "publisher": { "@type": "Person", "name": "Kranthi Manchikanti" },
+     "url": "https://ogkranthi.github.io/{filename}.html"
+   }
+   </script>
+   ```
+
+These are required. Do not publish a post without them.

--- a/.github/scripts/update-featured.py
+++ b/.github/scripts/update-featured.py
@@ -1,29 +1,39 @@
 #!/usr/bin/env python3
-"""Auto-update the featured post and post count in index.html.
+"""Auto-update the featured post, post count, RSS feed, and sitemap.
 
 Reads the first post card in the grid (newest post), pulls takeaway
 headings from the actual post HTML, and rewrites the featured section.
-Also syncs the "N Posts" counter.
+Also syncs the "N Posts" counter, generates feed.xml and sitemap.xml.
 """
 
+import datetime
+import os
 import re
 import sys
 from pathlib import Path
 
+SITE_URL = "https://ogkranthi.github.io"
+
+MONTH_MAP = {
+    "Jan": 1, "Feb": 2, "Mar": 3, "Apr": 4, "May": 5, "Jun": 6,
+    "Jul": 7, "Aug": 8, "Sep": 9, "Oct": 10, "Nov": 11, "Dec": 12,
+}
+
+CARD_PATTERN = re.compile(
+    r'<article\s+class="post-card[^"]*"[^>]*'
+    r"onclick=\"window\.location\.href='([^']+)'\""
+    r'[^>]*>'
+    r'.*?<h3>(.*?)</h3>'
+    r'.*?<p\s+class="post-excerpt">(.*?)</p>'
+    r'.*?<span\s+class="post-date">(.*?)</span>'
+    r'.*?</article>',
+    re.DOTALL,
+)
+
 
 def extract_first_card(html):
     """Extract info from the first post-card in the posts-grid."""
-    m = re.search(
-        r'<article\s+class="post-card[^"]*"[^>]*'
-        r"onclick=\"window\.location\.href='([^']+)'\""
-        r'[^>]*>'
-        r'.*?<h3>(.*?)</h3>'
-        r'.*?<p\s+class="post-excerpt">(.*?)</p>'
-        r'.*?<span\s+class="post-date">(.*?)</span>'
-        r'.*?</article>',
-        html,
-        re.DOTALL,
-    )
+    m = CARD_PATTERN.search(html)
     if not m:
         return None
     return {
@@ -32,6 +42,22 @@ def extract_first_card(html):
         "excerpt": m.group(3).strip(),
         "date_line": m.group(4).strip(),
     }
+
+
+def extract_all_cards(html):
+    """Extract all post cards from index.html."""
+    cards = []
+    for m in CARD_PATTERN.finditer(html):
+        href = m.group(1).strip()
+        if href == "#":
+            continue
+        cards.append({
+            "href": href,
+            "title": m.group(2).strip(),
+            "excerpt": m.group(3).strip(),
+            "date_line": m.group(4).strip(),
+        })
+    return cards
 
 
 def current_featured_href(html):
@@ -101,6 +127,104 @@ def build_featured_section(card, takeaways):
     )
 
 
+def escape_xml(text):
+    """Escape XML special characters."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def parse_post_date(date_line):
+    """Parse 'Mar 2026 · 15 min' into an RFC 822 date string."""
+    m = re.match(r"(\w+)\s+(\d{4})", date_line)
+    if not m:
+        return ""
+    month_str, year = m.group(1), int(m.group(2))
+    month = MONTH_MAP.get(month_str, 1)
+    dt = datetime.datetime(year, month, 1, tzinfo=datetime.timezone.utc)
+    return dt.strftime("%a, %d %b %Y %H:%M:%S +0000")
+
+
+def generate_feed(html):
+    """Generate feed.xml from post cards in index.html."""
+    cards = extract_all_cards(html)
+    if not cards:
+        print("No real post cards found, skipping feed generation")
+        return
+
+    items = []
+    for card in cards:
+        pub_date = parse_post_date(card["date_line"])
+        date_tag = f"\n      <pubDate>{pub_date}</pubDate>" if pub_date else ""
+        items.append(
+            f"    <item>\n"
+            f"      <title>{escape_xml(card['title'])}</title>\n"
+            f"      <link>{SITE_URL}/{card['href']}</link>\n"
+            f"      <guid>{SITE_URL}/{card['href']}</guid>\n"
+            f"      <description>{escape_xml(card['excerpt'])}</description>"
+            f"{date_tag}\n"
+            f"    </item>"
+        )
+
+    feed = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">\n'
+        "  <channel>\n"
+        "    <title>Kranthi Manchikanti</title>\n"
+        f"    <link>{SITE_URL}</link>\n"
+        f'    <atom:link href="{SITE_URL}/feed.xml" rel="self"'
+        f' type="application/rss+xml"/>\n'
+        "    <description>Technical deep-dives on AI Agents, AI Architectures,"
+        " Reinforcement Learning, HITL frameworks, and AI safety.</description>\n"
+        "    <language>en-us</language>\n"
+        + "\n".join(items)
+        + "\n"
+        "  </channel>\n"
+        "</rss>\n"
+    )
+
+    Path("feed.xml").write_text(feed, encoding="utf-8")
+    print(f"feed.xml generated with {len(cards)} items")
+
+
+def generate_sitemap():
+    """Generate sitemap.xml from HTML files on disk."""
+    pages = ["index.html"]
+    for f in sorted(Path(".").glob("*.html")):
+        if f.name != "index.html":
+            pages.append(f.name)
+
+    entries = []
+    for page in pages:
+        path = Path(page)
+        if not path.exists():
+            continue
+        mtime = datetime.datetime.fromtimestamp(
+            os.path.getmtime(path), tz=datetime.timezone.utc
+        )
+        lastmod = mtime.strftime("%Y-%m-%d")
+        entries.append(
+            f"  <url>\n"
+            f"    <loc>{SITE_URL}/{page}</loc>\n"
+            f"    <lastmod>{lastmod}</lastmod>\n"
+            f"  </url>"
+        )
+
+    sitemap = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        + "\n".join(entries)
+        + "\n"
+        "</urlset>\n"
+    )
+
+    Path("sitemap.xml").write_text(sitemap, encoding="utf-8")
+    print(f"sitemap.xml generated with {len(entries)} URLs")
+
+
 def main():
     index_path = Path("index.html")
     html = index_path.read_text(encoding="utf-8")
@@ -155,6 +279,10 @@ def main():
         print("index.html written")
     else:
         print("No changes needed")
+
+    # ── Generate feed and sitemap ──
+    generate_feed(html)
+    generate_sitemap()
 
 
 if __name__ == "__main__":

--- a/.github/workflows/update-featured.yml
+++ b/.github/workflows/update-featured.yml
@@ -22,9 +22,9 @@ jobs:
 
       - name: Commit if changed
         run: |
-          git diff --quiet index.html && exit 0
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add index.html
-          git commit -m "chore: auto-update featured post and post count"
+          git add index.html feed.xml sitemap.xml
+          git diff --cached --quiet && exit 0
+          git commit -m "chore: auto-update featured post, feed, and sitemap"
           git push

--- a/autoresearch-harness-engineering.html
+++ b/autoresearch-harness-engineering.html
@@ -8,6 +8,22 @@
 <meta property="og:title" content="AutoResearch, Harness Engineering, and the Next Layer of Agentic AI">
 <meta property="og:description" content="The real innovation in AutoResearch isn't autonomy — it's the constraints that make autonomy safe. A structural analysis of harness engineering for enterprise agentic AI.">
 <meta property="og:type" content="article">
+<link rel="canonical" href="https://ogkranthi.github.io/autoresearch-harness-engineering.html">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@ogkranthi">
+<meta name="twitter:title" content="AutoResearch, Harness Engineering, and the Next Layer of Agentic AI">
+<meta name="twitter:description" content="The real innovation in AutoResearch isn't autonomy — it's the constraints that make autonomy safe. A structural analysis of harness engineering for enterprise agentic AI.">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "AutoResearch, Harness Engineering, and the Next Layer of Agentic AI",
+  "description": "Andrej Karpathy's AutoResearch demonstrates harness engineering: bounded agent loops, narrow write surfaces, fixed evaluation budgets, and rollback discipline. What enterprises should copy — and what they shouldn't.",
+  "author": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "publisher": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "url": "https://ogkranthi.github.io/autoresearch-harness-engineering.html"
+}
+</script>
 <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/3d3eda9caaed2c475dba44126/f3ea9112071b1f2a08ad4ccce.js");</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/distillation-rl-guardrails.html
+++ b/distillation-rl-guardrails.html
@@ -8,6 +8,22 @@
 <meta property="og:title" content="Your API Is a Training Dataset: How Distillation Attacks Work and How to Stop Them">
 <meta property="og:description" content="DeepSeek, Moonshot, and MiniMax ran 16M+ exchanges to steal Claude's capabilities. Here's how distillation attacks work mechanically — and how to stop them.">
 <meta property="og:type" content="article">
+<link rel="canonical" href="https://ogkranthi.github.io/distillation-rl-guardrails.html">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@ogkranthi">
+<meta name="twitter:title" content="Your API Is a Training Dataset: How Distillation Attacks Work and How to Stop Them">
+<meta name="twitter:description" content="DeepSeek, Moonshot, and MiniMax ran 16M+ exchanges to steal Claude's capabilities. Here's how distillation attacks work mechanically — and how to stop them.">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Your API Is a Training Dataset: How Distillation Attacks Work and How to Stop Them",
+  "description": "How industrial-scale distillation attacks work, why RL makes them so powerful, and a layered guardrail checklist for every API and model builder.",
+  "author": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "publisher": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "url": "https://ogkranthi.github.io/distillation-rl-guardrails.html"
+}
+</script>
 <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/3d3eda9caaed2c475dba44126/f3ea9112071b1f2a08ad4ccce.js");</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/engram.html
+++ b/engram.html
@@ -8,6 +8,22 @@
 <meta property="og:title" content="DeepSeek Engram: Why the Future of AI Memory Starts Inside the Model">
 <meta property="og:description" content="Engram isn't just a memory system. It's a fundamental rethinking of how knowledge should be stored in large language models.">
 <meta property="og:type" content="article">
+<link rel="canonical" href="https://ogkranthi.github.io/engram.html">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@ogkranthi">
+<meta name="twitter:title" content="DeepSeek Engram: Why the Future of AI Memory Starts Inside the Model">
+<meta name="twitter:description" content="Engram isn't just a memory system. It's a fundamental rethinking of how knowledge should be stored in large language models.">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "DeepSeek Engram: Why the Future of AI Memory Starts Inside the Model",
+  "description": "A deep dive into DeepSeek's Engram architectural breakthrough — why AI memory needs to be solved at the hardware level, and what it means for Zep, Mem0, Letta, and the application memory ecosystem.",
+  "author": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "publisher": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "url": "https://ogkranthi.github.io/engram.html"
+}
+</script>
 <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/3d3eda9caaed2c475dba44126/f3ea9112071b1f2a08ad4ccce.js");</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Kranthi Manchikanti</title>
+    <link>https://ogkranthi.github.io</link>
+    <atom:link href="https://ogkranthi.github.io/feed.xml" rel="self" type="application/rss+xml"/>
+    <description>Technical deep-dives on AI Agents, AI Architectures, Reinforcement Learning, HITL frameworks, and AI safety.</description>
+    <language>en-us</language>
+    <item>
+      <title>Governed Agent Distribution Is Becoming the Enterprise Battleground</title>
+      <link>https://ogkranthi.github.io/governed-agent-distribution.html</link>
+      <guid>https://ogkranthi.github.io/governed-agent-distribution.html</guid>
+      <description>The next phase of enterprise AI adoption is not about model capability. It is about governed distribution: connectors, permissions, marketplaces, and admin controls that make agents deployable inside real enterprises.</description>
+      <pubDate>Sun, 01 Mar 2026 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>AutoResearch, Harness Engineering, and the Next Layer of Agentic AI</title>
+      <link>https://ogkranthi.github.io/autoresearch-harness-engineering.html</link>
+      <guid>https://ogkranthi.github.io/autoresearch-harness-engineering.html</guid>
+      <description>The real innovation in AutoResearch isn't autonomy — it's the constraints. Bounded loops, narrow write surfaces, fixed evaluation budgets, and rollback discipline. The scaffolding pattern enterprises should study for production agentic AI.</description>
+      <pubDate>Sun, 01 Mar 2026 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Your API Is a Training Dataset: How Distillation Attacks Work and How to Stop Them</title>
+      <link>https://ogkranthi.github.io/distillation-rl-guardrails.html</link>
+      <guid>https://ogkranthi.github.io/distillation-rl-guardrails.html</guid>
+      <description>DeepSeek, Moonshot, and MiniMax ran 16M+ exchanges to steal Claude's capabilities. How distillation attacks work mechanically — and a layered guardrail checklist for API and model builders.</description>
+      <pubDate>Sun, 01 Feb 2026 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Fine-Tuning a 1.2B LLM for Pediatric Disaster Response on the Edge</title>
+      <link>https://ogkranthi.github.io/pediatric-disaster-edge-ai.html</link>
+      <guid>https://ogkranthi.github.io/pediatric-disaster-edge-ai.html</guid>
+      <description>How we fine-tuned LiquidAI's LFM2.5-1.2B on JumpSTART triage protocols using Unsloth + Hugging Face Jobs — and built a model that runs under 1GB RAM with zero internet connectivity on field devices.</description>
+      <pubDate>Sun, 01 Feb 2026 00:00:00 +0000</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/governed-agent-distribution.html
+++ b/governed-agent-distribution.html
@@ -8,6 +8,22 @@
 <meta property="og:title" content="Governed Agent Distribution Is Becoming the Enterprise Battleground">
 <meta property="og:description" content="Connectors, permissions, marketplaces, and admin controls are now more decisive than model capability for enterprise AI adoption. A deep dive into governed agent distribution architecture.">
 <meta property="og:type" content="article">
+<link rel="canonical" href="https://ogkranthi.github.io/governed-agent-distribution.html">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@ogkranthi">
+<meta name="twitter:title" content="Governed Agent Distribution Is Becoming the Enterprise Battleground">
+<meta name="twitter:description" content="Connectors, permissions, marketplaces, and admin controls are now more decisive than model capability for enterprise AI adoption. A deep dive into governed agent distribution architecture.">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Governed Agent Distribution Is Becoming the Enterprise Battleground",
+  "description": "The next phase of enterprise AI adoption is not about model capability. It is about governed distribution: connectors, permissions, marketplaces, and admin controls that make agents deployable inside real enterprises.",
+  "author": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "publisher": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "url": "https://ogkranthi.github.io/governed-agent-distribution.html"
+}
+</script>
 <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/3d3eda9caaed2c475dba44126/f3ea9112071b1f2a08ad4ccce.js");</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,21 @@
 <meta property="og:title" content="Kranthi Manchikanti | AI Agents, Architectures & Applied Research">
 <meta property="og:description" content="AI Agents, AI Architectures, Reinforcement Learning, HITL systems, and AI safety. Written from experience across high tech, finance and healthcare industries.">
 <meta property="og:type" content="website">
+<link rel="canonical" href="https://ogkranthi.github.io/">
+<link rel="alternate" type="application/rss+xml" title="Kranthi Manchikanti" href="https://ogkranthi.github.io/feed.xml">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@ogkranthi">
+<meta name="twitter:title" content="Kranthi Manchikanti | AI Agents, Architectures &amp; Applied Research">
+<meta name="twitter:description" content="AI Agents, AI Architectures, Reinforcement Learning, HITL systems, and AI safety. Written from experience across high tech, finance and healthcare industries.">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Kranthi Manchikanti",
+  "url": "https://ogkranthi.github.io",
+  "description": "Technical deep-dives on AI Agents, AI Architectures, Reinforcement Learning, HITL frameworks, and AI safety."
+}
+</script>
 <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/3d3eda9caaed2c475dba44126/f3ea9112071b1f2a08ad4ccce.js");</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/pediatric-disaster-edge-ai.html
+++ b/pediatric-disaster-edge-ai.html
@@ -8,6 +8,22 @@
 <meta property="og:title" content="Fine-Tuning a 1.2B LLM for Pediatric Disaster Response on the Edge">
 <meta property="og:description" content="SFT with LoRA, Unsloth optimizations, HF Jobs for cloud training, and GGUF export for offline deployment. A complete technical walkthrough.">
 <meta property="og:type" content="article">
+<link rel="canonical" href="https://ogkranthi.github.io/pediatric-disaster-edge-ai.html">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@ogkranthi">
+<meta name="twitter:title" content="Fine-Tuning a 1.2B LLM for Pediatric Disaster Response on the Edge">
+<meta name="twitter:description" content="SFT with LoRA, Unsloth optimizations, HF Jobs for cloud training, and GGUF export for offline deployment. A complete technical walkthrough.">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Fine-Tuning a 1.2B LLM for Pediatric Disaster Response on the Edge",
+  "description": "How we fine-tuned LiquidAI's LFM2.5-1.2B on pediatric triage protocols using Unsloth + Hugging Face — and built a model that runs offline, under 1GB RAM, on field devices with no connectivity.",
+  "author": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "publisher": { "@type": "Person", "name": "Kranthi Manchikanti" },
+  "url": "https://ogkranthi.github.io/pediatric-disaster-edge-ai.html"
+}
+</script>
 <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/3d3eda9caaed2c475dba44126/f3ea9112071b1f2a08ad4ccce.js");</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://ogkranthi.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://ogkranthi.github.io/index.html</loc>
+    <lastmod>2026-03-11</lastmod>
+  </url>
+  <url>
+    <loc>https://ogkranthi.github.io/autoresearch-harness-engineering.html</loc>
+    <lastmod>2026-03-11</lastmod>
+  </url>
+  <url>
+    <loc>https://ogkranthi.github.io/distillation-rl-guardrails.html</loc>
+    <lastmod>2026-03-11</lastmod>
+  </url>
+  <url>
+    <loc>https://ogkranthi.github.io/engram.html</loc>
+    <lastmod>2026-03-11</lastmod>
+  </url>
+  <url>
+    <loc>https://ogkranthi.github.io/governed-agent-distribution.html</loc>
+    <lastmod>2026-03-11</lastmod>
+  </url>
+  <url>
+    <loc>https://ogkranthi.github.io/pediatric-disaster-edge-ai.html</loc>
+    <lastmod>2026-03-11</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- **RSS feed** (`feed.xml`) — auto-generated from post cards by GitHub Action, title + excerpt format
- **Sitemap** (`sitemap.xml`) — auto-generated from HTML files on disk with last-modified dates
- **robots.txt** — allows all crawlers, points to sitemap
- **Twitter/X card meta tags** — added to all 6 HTML pages for better social sharing previews
- **JSON-LD structured data** — `WebSite` schema on index, `Article` schema on each post for rich search results
- **Canonical URLs** — added to all pages
- **RSS autodiscovery** — `<link rel="alternate">` in index.html head
- **Copilot instructions** updated with SEO requirements so future posts include all meta tags automatically

## Automation
The existing `update-featured.yml` workflow now also regenerates `feed.xml` and `sitemap.xml` on every push to main, so they stay current without manual intervention.

## Test plan
- [x] Ran update script locally — feed.xml (4 items) and sitemap.xml (6 URLs) generated correctly
- [x] Verified valid RSS 2.0 and sitemap XML structure
- [ ] Validate with Google Rich Results Test after deploy
- [ ] Validate RSS with an RSS reader after deploy