### PR TITLE
fix: ai_innovator badge extension and PeerGraph dark card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1125,7 +1125,7 @@ footer p {
       <img src="images/msft_ecosystem_kk_3.jpg" alt="Microsoft Agentic Ecosystem Workshop — audience">
       <img src="images/cert_dev_kk.jpg" alt="Certification">
       <img src="images/HITL_kk.jpg" alt="Human-in-the-Loop AI">
-      <img src="images/ai_innovator_kk.jpg" alt="AI Innovator">
+      <img src="images/ai_innovator_kk.png" alt="AI Innovator">
       <!-- duplicate for seamless loop -->
       <img src="images/aws_kk.jpg" alt="AWS event">
       <img src="images/ChainfAgent_kk.jpg" alt="Chain of Verification Agent — poster presentation">
@@ -1141,7 +1141,7 @@ footer p {
       <img src="images/msft_ecosystem_kk_3.jpg" alt="Microsoft Agentic Ecosystem Workshop — audience">
       <img src="images/cert_dev_kk.jpg" alt="Certification">
       <img src="images/HITL_kk.jpg" alt="Human-in-the-Loop AI">
-      <img src="images/ai_innovator_kk.jpg" alt="AI Innovator">
+      <img src="images/ai_innovator_kk.png" alt="AI Innovator">
     </div>
   </div>
   <div class="marquee-row marquee-row-reverse">
@@ -1158,7 +1158,7 @@ footer p {
       <img src="images/msft_ecosystem_kk_3.jpg" alt="Microsoft Agentic Ecosystem Workshop — audience">
       <img src="images/msft_ecosystem_kk_1.jpg" alt="Microsoft Agentic Ecosystem Workshop — Burlington MA">
       <img src="images/msft_ecosystem_kk_2.jpg" alt="Microsoft Agentic Ecosystem Workshop — session">
-      <img src="images/ai_innovator_kk.jpg" alt="AI Innovator">
+      <img src="images/ai_innovator_kk.png" alt="AI Innovator">
       <img src="images/HITL_kk.jpg" alt="Human-in-the-Loop AI">
       <img src="images/cert_dev_kk.jpg" alt="Certification">
       <!-- duplicate -->
@@ -1174,7 +1174,7 @@ footer p {
       <img src="images/msft_ecosystem_kk_3.jpg" alt="Microsoft Agentic Ecosystem Workshop — audience">
       <img src="images/msft_ecosystem_kk_1.jpg" alt="Microsoft Agentic Ecosystem Workshop — Burlington MA">
       <img src="images/msft_ecosystem_kk_2.jpg" alt="Microsoft Agentic Ecosystem Workshop — session">
-      <img src="images/ai_innovator_kk.jpg" alt="AI Innovator">
+      <img src="images/ai_innovator_kk.png" alt="AI Innovator">
       <img src="images/HITL_kk.jpg" alt="Human-in-the-Loop AI">
       <img src="images/cert_dev_kk.jpg" alt="Certification">
     </div>
@@ -1308,13 +1308,13 @@ footer p {
         <span class="project-cta">View on GitHub ↗</span>
       </a>
 
-      <a href="https://www.peergraph.ai/" target="_blank" rel="noopener" class="project-card">
+      <a href="https://www.peergraph.ai/" target="_blank" rel="noopener" class="project-card project-card-featured">
         <div class="project-card-header">
           <span class="project-tag open-source">Open Source</span>
         </div>
         <div class="project-title">PeerGraph</div>
         <div class="project-desc">An open graph connecting AI researchers with product builders — visualizing how academic research translates into real-world applications. Maps 144+ researchers, 90+ builders, and 216 research-to-product connections across 50+ AI domains. Introduces the Applied Impact Index: a metric for real-world adoption beyond citation counts.</div>
-        <span class="project-link">View PeerGraph ↗</span>
+        <span class="project-cta">View PeerGraph ↗</span>
       </a>
 
       <a href="https://www.kaggle.com/benchmarks/ogkranthi22/cogcontrol-stakes-metacognition" target="_blank" rel="noopener" class="project-card">


### PR DESCRIPTION
## Summary
- Fix ai_innovator_kk.jpg → ai_innovator_kk.png (was not rendering because extension was wrong)
- Apply project-card-featured styling to PeerGraph — same dark navy card as AgentShift