### PR TITLE
feat: site-wide search overlay in nav with talks, projects, articles, Substack

### DIFF
--- a/index.html
+++ b/index.html
@@ -1027,75 +1027,119 @@ footer p {
   transform: translateY(0);
 }
 
-/* ── ASK MY WRITING — SEARCH ── */
-.writing-search-wrap {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 0 2.5rem 1.75rem;
-}
-
-.writing-search-bar {
-  position: relative;
-}
-
-.writing-search-bar input {
-  width: 100%;
-  padding: 0.75rem 1rem 0.75rem 2.75rem;
-  font-family: var(--sans);
-  font-size: 0.88rem;
+/* ── SEARCH ── */
+.nav-search-btn {
+  background: none;
   border: 1px solid var(--border);
-  border-radius: 10px;
-  background: #fafafa;
-  color: var(--text-primary);
-  outline: none;
-  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
-  box-sizing: border-box;
-}
-
-.writing-search-bar input:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(30,64,175,0.08);
-  background: #fff;
-}
-
-.writing-search-bar input::placeholder { color: #a0a0a8; }
-
-.search-icon {
-  position: absolute;
-  left: 0.85rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #a0a0a8;
-  pointer-events: none;
+  border-radius: 7px;
+  padding: 0.35rem 0.55rem;
+  cursor: pointer;
+  color: var(--text-secondary);
   display: flex;
+  align-items: center;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
+  margin-left: 0.25rem;
+}
+.nav-search-btn:hover { border-color: var(--accent); color: var(--accent); background: #eef2ff; }
+
+.search-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  background: rgba(15,15,15,0.55);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 10vh;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease;
+}
+.search-overlay.open { opacity: 1; pointer-events: all; }
+
+.search-overlay-inner {
+  width: 100%;
+  max-width: 680px;
+  margin: 0 1.5rem;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 24px 64px rgba(0,0,0,0.18);
+  overflow: hidden;
+  transform: translateY(-12px);
+  transition: transform 0.18s ease;
+}
+.search-overlay.open .search-overlay-inner { transform: translateY(0); }
+
+.search-overlay-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.search-overlay-bar input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-family: var(--sans);
+  font-size: 1rem;
+  color: var(--text-primary);
+  background: transparent;
+}
+.search-overlay-bar input::placeholder { color: #a0a0a8; }
+
+.search-close-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.2rem 0.5rem;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-shrink: 0;
+  transition: border-color 0.15s;
+}
+.search-close-btn:hover { border-color: #9ca3af; }
+
+.search-overlay-hint {
+  padding: 0.55rem 1.25rem;
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.04em;
+  color: #b0b0b8;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--border);
 }
 
 .search-results {
-  margin-top: 0.75rem;
+  padding: 0.75rem;
   display: none;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
+  max-height: 60vh;
+  overflow-y: auto;
 }
-
 .search-results.active { display: flex; }
 
 .search-result-item {
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
-  padding: 0.9rem 1rem;
+  padding: 0.85rem 1rem;
   border: 1px solid var(--border);
   border-radius: 9px;
   background: #fff;
   text-decoration: none;
   color: inherit;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition: border-color 0.15s, background 0.15s;
 }
-
-.search-result-item:hover {
-  border-color: #c7d2fe;
-  box-shadow: 0 4px 16px rgba(30,64,175,0.08);
-}
+.search-result-item:hover { border-color: #c7d2fe; background: #fafbff; }
 
 .search-result-header {
   display: flex;
@@ -1112,16 +1156,10 @@ footer p {
   border-radius: 4px;
   flex-shrink: 0;
 }
-
-.search-result-source.article {
-  background: #eef2ff;
-  color: #4338ca;
-}
-
-.search-result-source.substack {
-  background: #fff7ed;
-  color: #c2410c;
-}
+.search-result-source.article  { background: #eef2ff; color: #4338ca; }
+.search-result-source.substack { background: #fff7ed; color: #c2410c; }
+.search-result-source.talk     { background: #f0fdf4; color: #15803d; }
+.search-result-source.project  { background: #0f172a; color: #93c5fd; }
 
 .search-result-title {
   font-family: var(--serif);
@@ -1141,28 +1179,13 @@ footer p {
   overflow: hidden;
 }
 
-.search-result-item mark {
-  background: #fef9c3;
-  color: inherit;
-  border-radius: 2px;
-  padding: 0 1px;
-}
+.search-result-item mark { background: #fef9c3; color: inherit; border-radius: 2px; padding: 0 1px; }
 
 .search-no-results {
-  padding: 0.85rem 1rem;
+  padding: 2rem 1rem;
   font-size: 0.83rem;
   color: var(--text-secondary);
   text-align: center;
-  border: 1px dashed var(--border);
-  border-radius: 9px;
-}
-
-.search-hint {
-  font-size: 0.73rem;
-  color: #b0b0b8;
-  margin-top: 0.4rem;
-  font-family: var(--mono);
-  letter-spacing: 0.02em;
 }
 
 /* ── RESPONSIVE ── */
@@ -1204,8 +1227,27 @@ footer p {
     <a href="#writing">Writing</a>
     <a href="https://aiengineerweekly.substack.com" target="_blank" class="nav-cta">Newsletter →</a>
     <a href="#connect">Contact</a>
+    <button class="nav-search-btn" id="search-open" aria-label="Search" title="Search everything">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+    </button>
   </nav>
 </header>
+
+<!-- SEARCH OVERLAY -->
+<div class="search-overlay" id="search-overlay" aria-hidden="true">
+  <div class="search-overlay-inner">
+    <div class="search-overlay-bar">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;color:#6b7280"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      <input type="text" id="writing-search" placeholder="Search talks, projects, articles, newsletter…" autocomplete="off" spellcheck="false">
+      <button class="search-close-btn" id="search-close" aria-label="Close search">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+        <span>ESC</span>
+      </button>
+    </div>
+    <div class="search-overlay-hint">Searches across articles, Substack posts, talks, and projects</div>
+    <div class="search-results" id="search-results"></div>
+  </div>
+</div>
 
 <!-- HERO -->
 <section class="hero">
@@ -1539,16 +1581,6 @@ footer p {
   <span class="count">17 Posts</span>
 </div>
 
-<div class="writing-search-wrap">
-  <div class="writing-search-bar">
-    <span class="search-icon">
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-    </span>
-    <input type="text" id="writing-search" placeholder="Ask my writing — try 'RAG evaluation', 'agentic governance', 'edge AI'…" autocomplete="off" spellcheck="false">
-  </div>
-  <div class="search-hint">Searches across 9 articles + 7 Substack posts</div>
-  <div class="search-results" id="search-results"></div>
-</div>
 
 <div class="posts-grid">
 
@@ -1779,12 +1811,34 @@ const observer = new IntersectionObserver((entries) => {
 document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
 </script>
 
-<!-- Ask My Writing — Search -->
+<!-- Search -->
 <script>
 (function() {
   const STOPWORDS = new Set(['a','an','the','and','or','but','in','on','at','to','for','of','with','by','from','is','are','was','were','be','been','being','have','has','had','do','does','did','will','would','could','should','may','might','that','this','these','those','it','its','i','you','we','they','he','she','what','how','when','where','why','which','who','not','no','can','about','into','than','then','as','if','so','just','also','more','my','your','their','our','all','any','some']);
 
   let index = null;
+  const overlay = document.getElementById('search-overlay');
+  const input = document.getElementById('writing-search');
+  const resultsEl = document.getElementById('search-results');
+
+  function openSearch() {
+    overlay.classList.add('open');
+    overlay.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+    setTimeout(() => input && input.focus(), 80);
+  }
+
+  function closeSearch() {
+    overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+    if (input) { input.value = ''; }
+    if (resultsEl) { resultsEl.classList.remove('active'); resultsEl.innerHTML = ''; }
+  }
+
+  document.getElementById('search-open').addEventListener('click', openSearch);
+  document.getElementById('search-close').addEventListener('click', closeSearch);
+  overlay.addEventListener('click', e => { if (e.target === overlay) closeSearch(); });
 
   function tokenize(text) {
     return text.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(t => t.length > 2 && !STOPWORDS.has(t));
@@ -1796,30 +1850,24 @@ document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
     return text.replace(re, '<mark>$1</mark>');
   }
 
-  function score(article, queryTokens) {
+  function scoreArticle(article, queryTokens) {
     let s = 0;
     const titleTokens = tokenize(article.title);
     const excerptTokens = tokenize(article.excerpt);
     queryTokens.forEach(qt => {
-      // Title match: high weight
       if (titleTokens.some(t => t.includes(qt) || qt.includes(t))) s += 8;
-      // Tag match
       article.tags.forEach(tag => { if (tag.toLowerCase().includes(qt)) s += 4; });
-      // Excerpt match
       if (excerptTokens.some(t => t.includes(qt) || qt.includes(t))) s += 3;
-      // Chunk match
       article.chunks.forEach(chunk => {
         const ct = tokenize(chunk);
-        const matches = ct.filter(t => t.includes(qt) || qt.includes(t)).length;
-        s += matches * 1;
+        s += ct.filter(t => t.includes(qt) || qt.includes(t)).length;
       });
     });
     return s;
   }
 
   function bestChunk(article, queryTokens) {
-    let best = article.excerpt;
-    let bestScore = 0;
+    let best = article.excerpt; let bestScore = 0;
     article.chunks.forEach(chunk => {
       const ct = tokenize(chunk);
       const s = ct.filter(t => queryTokens.some(qt => t.includes(qt) || qt.includes(t))).length;
@@ -1828,59 +1876,60 @@ document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
     return best;
   }
 
+  const SOURCE_LABELS = { article: 'Article', substack: 'Substack', talk: 'Talk', project: 'Project' };
+
   function render(results, queryTokens) {
-    const container = document.getElementById('search-results');
     if (!results.length) {
-      container.innerHTML = '<div class="search-no-results">No results found — try different keywords</div>';
-      container.classList.add('active');
+      resultsEl.innerHTML = '<div class="search-no-results">No results — try different keywords</div>';
+      resultsEl.classList.add('active');
       return;
     }
-    container.innerHTML = results.map(a => {
+    resultsEl.innerHTML = results.map(a => {
       const snippet = bestChunk(a, queryTokens);
-      const snippetHtml = highlight(snippet.length > 180 ? snippet.slice(0, 177) + '…' : snippet, queryTokens);
+      const snippetHtml = highlight(snippet.length > 200 ? snippet.slice(0, 197) + '…' : snippet, queryTokens);
       const titleHtml = highlight(a.title, queryTokens);
       const isExternal = a.url.startsWith('http');
-      return `<a href="${a.url}" ${isExternal ? 'target="_blank" rel="noopener"' : ''} class="search-result-item">
+      return `<a href="${a.url || '#'}" ${isExternal ? 'target="_blank" rel="noopener"' : ''} class="search-result-item" onclick="closeSearch && setTimeout(closeSearch,80)">
         <div class="search-result-header">
-          <span class="search-result-source ${a.source}">${a.source === 'substack' ? 'Substack' : 'Article'}</span>
+          <span class="search-result-source ${a.source}">${SOURCE_LABELS[a.source] || a.source}</span>
           <span class="search-result-title">${titleHtml}</span>
         </div>
         <div class="search-result-snippet">${snippetHtml}</div>
       </a>`;
     }).join('');
-    container.classList.add('active');
+    resultsEl.classList.add('active');
   }
 
   function search(query) {
-    const container = document.getElementById('search-results');
-    if (!query.trim()) { container.classList.remove('active'); container.innerHTML = ''; return; }
+    if (!query.trim()) { resultsEl.classList.remove('active'); resultsEl.innerHTML = ''; return; }
     if (!index) return;
     const queryTokens = tokenize(query);
-    if (!queryTokens.length) { container.classList.remove('active'); return; }
+    if (!queryTokens.length) { resultsEl.classList.remove('active'); return; }
     const scored = index.articles
-      .map(a => ({ article: a, score: score(a, queryTokens) }))
+      .map(a => ({ article: a, score: scoreArticle(a, queryTokens) }))
       .filter(x => x.score > 0)
       .sort((a, b) => b.score - a.score)
-      .slice(0, 5)
+      .slice(0, 7)
       .map(x => x.article);
     render(scored, queryTokens);
   }
 
-  // Load index and wire input
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') { closeSearch(); return; }
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') { e.preventDefault(); openSearch(); }
+  });
+
   fetch('search-index.json')
     .then(r => r.json())
     .then(data => {
       index = data;
-      const input = document.getElementById('writing-search');
-      if (!input) return;
       let debounce;
       input.addEventListener('input', e => {
         clearTimeout(debounce);
-        debounce = setTimeout(() => search(e.target.value), 180);
+        debounce = setTimeout(() => search(e.target.value), 160);
       });
-      input.addEventListener('keydown', e => { if (e.key === 'Escape') { input.value = ''; search(''); input.blur(); } });
     })
-    .catch(() => {}); // fail silently if index not found
+    .catch(() => {});
 })();
 </script>
 

--- a/search-index.json
+++ b/search-index.json
@@ -10,9 +10,8 @@
       "excerpt": "A practical selection framework for enterprise teams choosing between AI coworker categories — by control-plane fit, privilege scope, and reviewability.",
       "chunks": [
         "The market has split into five distinct AI coworker categories, each inheriting a different control plane: personal assistant agents like OpenClaw, repo-native coding agents like GitHub Copilot, terminal and editor-native agents like Claude Code and Cursor, browser and computer-use agents, and scheduled task agents. The best alternative to OpenClaw is not the strongest model — it is the agent whose execution surface already lives where your work lives.",
-        "The right question is: what execution surface should this agent inherit? If the task belongs in a pull request, an agent that runs in chat will always be fighting its own architecture to get there. If the task belongs in a terminal loop with explicit approval gates, a browser-based agent is solving the wrong problem.",
-        "The model quality gap between leading tools is narrowing fast. The control-plane gap is not. Enterprise teams that anchor their agent selection to execution surface — not benchmark scores — will ship faster and debug less.",
-        "Control plane fit determines privilege scope, reviewability, and auditability. An agent that inherits your repo's permission model can be audited like code. An agent that inherits a chat interface cannot. For regulated industries, this distinction is not architectural preference — it is compliance."
+        "The right question is: what execution surface should this agent inherit? If the task belongs in a pull request, an agent that runs in chat will always be fighting its own architecture to get there. The model quality gap between leading tools is narrowing fast. The control-plane gap is not.",
+        "Control plane fit determines privilege scope, reviewability, and auditability. An agent that inherits your repo's permission model can be audited like code. For regulated industries, this distinction is not architectural preference — it is compliance."
       ]
     },
     {
@@ -24,10 +23,9 @@
       "date": "Mar 2026",
       "excerpt": "The next phase of enterprise AI is not about model capability — it is about governed distribution: connectors, permissions, marketplaces, and admin controls.",
       "chunks": [
-        "The barrier to enterprise AI adoption is distribution — not in the logistics sense, but in the governance sense. Can this agent be deployed inside my enterprise without violating data residency requirements? Can I restrict which business units have access? Can my security team audit what it touched? Can I revoke access instantly if something goes wrong?",
-        "Recent enterprise AI platform launches — from Microsoft Copilot Studio's expanded connector catalog, to Salesforce AgentForce's permission model, to ServiceNow's agent governance controls — all point in the same direction. The vendors that understand this are building distribution infrastructure, not just model capability.",
-        "Governed agent distribution requires four architectural layers: identity and permission propagation, connector governance, behavioral audit trails, and marketplace controls that allow enterprises to curate which agents employees can access.",
-        "The enterprise that controls the agent distribution layer controls the AI adoption stack. This is why Microsoft, Salesforce, and ServiceNow are investing heavily in agent marketplaces and admin consoles — the battle for enterprise AI is being fought at the distribution layer, not the model layer."
+        "The barrier to enterprise AI adoption is distribution — in the governance sense. Can this agent be deployed inside my enterprise without violating data residency requirements? Can I restrict which business units have access? Can my security team audit what it touched?",
+        "Microsoft Copilot Studio, Salesforce AgentForce, and ServiceNow's agent governance controls all point in the same direction: the vendors that understand this are building distribution infrastructure, not just model capability.",
+        "The enterprise that controls the agent distribution layer controls the AI adoption stack. The battle for enterprise AI is being fought at the distribution layer, not the model layer."
       ]
     },
     {
@@ -39,10 +37,9 @@
       "date": "Mar 2026",
       "excerpt": "The real innovation in AutoResearch isn't autonomy — it's the constraints. Bounded loops, narrow write surfaces, fixed evaluation budgets, and rollback discipline.",
       "chunks": [
-        "AutoResearch doesn't give an agent a blank canvas. It operates inside a tightly engineered harness: fixed compute budgets, narrow code mutation surfaces, automated evaluation against explicit metrics, and rollback rules that prevent the system from drifting into unrecoverable states. The agent is powerful because it is constrained, not despite it.",
-        "Harness engineering is the discipline of building the scaffolding around an agent that makes its autonomy safe and productive. A well-designed harness defines the agent's write surface — what it can touch — its evaluation budget — how many iterations before it stops — and its rollback discipline — how it recovers from failure.",
-        "The pattern generalizes beyond ML experiments. Every production agentic system that works reliably at enterprise scale has three properties: a narrow, well-defined write surface; an evaluation loop with explicit exit criteria; and a rollback or undo mechanism for every irreversible action.",
-        "The gap between impressive demos and reliable production agents is almost always a harness engineering gap, not a model capability gap. Teams that ship reliable agents spend more time on scaffolding design than on model selection."
+        "AutoResearch operates inside a tightly engineered harness: fixed compute budgets, narrow code mutation surfaces, automated evaluation against explicit metrics, and rollback rules that prevent the system from drifting into unrecoverable states. The agent is powerful because it is constrained, not despite it.",
+        "Harness engineering defines the agent's write surface, its evaluation budget, and its rollback discipline. Every production agentic system that works reliably has these three properties.",
+        "The gap between impressive demos and reliable production agents is almost always a harness engineering gap, not a model capability gap."
       ]
     },
     {
@@ -54,10 +51,9 @@
       "date": "Feb 2026",
       "excerpt": "DeepSeek, Moonshot, and MiniMax ran 16M+ exchanges to steal Claude's capabilities. How distillation attacks work and a layered guardrail checklist.",
       "chunks": [
-        "In late 2024 and early 2025, three AI labs ran an industrial-scale campaign to steal Claude's capabilities — not by hacking servers, but by talking to it. Across 24,000 fraudulent accounts, they generated over 16 million exchanges to build a dataset of Claude's reasoning traces, agentic behaviors, and chain-of-thought patterns.",
-        "This is knowledge distillation as an attack vector. The target model becomes an involuntary teacher. Every response it generates — every reasoning trace, every step-by-step explanation — can be used as training signal. The attacker does not need access to the model weights. They only need API access.",
-        "A layered guardrail system for distillation defense includes: output fingerprinting to detect systematic pattern harvesting; rate limiting with behavioral anomaly detection; reasoning trace suppression for API responses; account cluster detection to identify coordinated extraction campaigns.",
-        "The uncomfortable implication: every API you expose is also a potential training dataset for your competitors. Guardrail design is no longer just about preventing harmful outputs — it is about protecting your model's intellectual property from extraction at scale."
+        "Three AI labs ran an industrial-scale campaign to steal Claude's capabilities — not by hacking servers, but by talking to it. Across 24,000 fraudulent accounts, they generated over 16 million exchanges to build a dataset of Claude's reasoning traces, agentic behaviors, and chain-of-thought patterns.",
+        "This is knowledge distillation as an attack vector. The target model becomes an involuntary teacher. Every response it generates — every reasoning trace, every step-by-step explanation — can be used as training signal.",
+        "Every API you expose is also a potential training dataset for your competitors. Guardrail design is no longer just about preventing harmful outputs — it is about protecting your model's intellectual property from extraction at scale."
       ]
     },
     {
@@ -67,12 +63,11 @@
       "source": "article",
       "tags": ["Edge AI", "Fine-Tuning", "Healthcare AI"],
       "date": "Feb 2026",
-      "excerpt": "How we fine-tuned LiquidAI's LFM2.5-1.2B on JumpSTART triage protocols — a model that runs under 1GB RAM with zero internet connectivity on field devices.",
+      "excerpt": "How we fine-tuned LiquidAI's LFM2.5-1.2B on JumpSTART triage protocols — a model that runs under 1GB RAM with zero internet on field devices.",
       "chunks": [
-        "In a mass casualty event — an earthquake, a flood, a building collapse — first responders face decisions that kill or save children in seconds. JumpSTART triage asks: is the child breathing? What is the respiratory rate? Is the radial pulse present? These protocols are well-established. The problem is the gap between protocol knowledge and field availability.",
-        "In disaster zones, connectivity collapses. There is no 4G. There is no cloud API to call. The field device may be a ruggedized Android tablet or an older laptop. RAM is constrained. Battery is limited. The model must run locally, instantly, with enough medical accuracy to guide triage decisions without expert oversight.",
-        "We used Unsloth with 4-bit QLoRA quantization to fine-tune LiquidAI's LFM2.5-1.2B on JumpSTART, PALS, SALT, and Broselow protocols. The resulting model runs under 1GB RAM and achieves 94.2% accuracy on held-out pediatric triage scenarios — compared to 71.3% for the untuned base model.",
-        "The technical choices compound: Liquid Foundation Models use a state-space architecture that is more parameter-efficient than transformers at sub-2B scale. QLoRA quantization reduces memory footprint without significant accuracy loss. The combination produces a model that runs offline, fits on low-end hardware, and outperforms general-purpose LLMs on domain-specific triage tasks."
+        "In disaster zones, connectivity collapses. There is no 4G, no cloud API. The model must run locally, instantly, with enough medical accuracy to guide pediatric triage decisions without expert oversight on-site.",
+        "We used Unsloth with 4-bit QLoRA quantization to fine-tune LFM2.5-1.2B on JumpSTART, PALS, SALT, and Broselow protocols. The result runs under 1GB RAM and achieves 94.2% accuracy on held-out pediatric triage scenarios.",
+        "Liquid Foundation Models use a state-space architecture that is more parameter-efficient than transformers at sub-2B scale. QLoRA quantization reduces memory footprint without significant accuracy loss — producing a model that runs offline on low-end hardware."
       ]
     },
     {
@@ -84,10 +79,9 @@
       "date": "Feb 2026",
       "excerpt": "A deep dive into the architectural breakthrough that challenges how we store knowledge in LLMs — and what it means for Zep, Mem0, Letta.",
       "chunks": [
-        "Engram forces a fundamental question: where should knowledge live in an AI system, and at what level of the stack should memory be solved? Right now we have two dominant paradigms — bake all knowledge into model weights during training, or build memory systems at the application layer like Zep, Mem0, and Letta. Engram proposes a third path at the hardware-adjacent, architecture level.",
-        "Conditional Memory via Scalable Lookup introduces a new axis of sparsity. Instead of activating the full parameter space for every token, Engram routes each query to a small, dynamically selected subset of memory blocks. The selection is learned, not hand-engineered. This changes the fundamental economics of knowledge storage in transformers.",
-        "If memory can be solved at the architecture level — efficiently, without application-layer scaffolding — the entire category of external memory systems built on RAG and vector databases faces a deeper challenge than any benchmark comparison. Not obsolescence, but repositioning.",
-        "The Engram architecture separates episodic from semantic memory at the weight level. This is not a retrieval trick — it is a fundamentally different approach to the knowledge organization problem that application-layer memory systems have been solving from the outside."
+        "Engram forces a fundamental question: where should knowledge live in an AI system? Right now we have two dominant paradigms — bake all knowledge into model weights during training, or build memory systems at the application layer like Zep, Mem0, and Letta. Engram proposes a third path at the architecture level.",
+        "Conditional Memory via Scalable Lookup introduces a new axis of sparsity. Instead of activating the full parameter space for every token, Engram routes each query to a small, dynamically selected subset of memory blocks.",
+        "If memory can be solved at the architecture level, the entire category of external memory systems built on RAG and vector databases faces a deeper repositioning challenge."
       ]
     },
     {
@@ -97,12 +91,11 @@
       "source": "article",
       "tags": ["Certification", "Claude", "Agentic Architecture"],
       "date": "Mar 2026",
-      "excerpt": "Complete guide to Anthropic's Claude Certified Architect — Foundations: exam format, five domains, six scenarios, preparation strategy, and free resources.",
+      "excerpt": "Complete guide to Anthropic's Claude Certified Architect — Foundations: exam format, five domains, preparation strategy, and free resources.",
       "chunks": [
-        "The Claude Certified Architect — Foundations is a proctored, scenario-based exam that tests whether you can design production AI systems using Claude's architecture stack. It is the first credential in the industry that validates the ability to build real agentic systems — not just prompt a chatbot, but architect multi-agent workflows, design tool integrations, and engineer for reliability at scale.",
-        "The certification covers five domains: agentic system design and orchestration, tool use and integration patterns, production environment configuration, safety and reliability engineering, and evaluation and monitoring architectures. Each scenario presents a realistic enterprise deployment challenge.",
-        "The exam consists of 60 scenario-based questions. Four scenarios are drawn from a pool of six. Passing score is 720 out of 1,000. It is currently available to Anthropic partner organizations as part of the $100 million Claude Partner Network investment for 2026.",
-        "Preparation strategy: spend 40% of study time on agentic system design patterns, 25% on tool integration, 20% on safety and reliability, and 15% on evaluation. The scenario-based format rewards systems thinking over factual recall — build mental models, not memorization."
+        "The Claude Certified Architect — Foundations is a proctored, scenario-based exam that tests whether you can design production AI systems using Claude's architecture stack. It validates the ability to build real agentic systems — not just prompt a chatbot, but architect multi-agent workflows.",
+        "The certification covers five domains: agentic system design, tool use and integration, production environment configuration, safety and reliability engineering, and evaluation and monitoring architectures.",
+        "Preparation strategy: spend 40% of study time on agentic system design patterns, 25% on tool integration, 20% on safety and reliability, and 15% on evaluation."
       ]
     },
     {
@@ -114,10 +107,9 @@
       "date": "Mar 2026",
       "excerpt": "Domain-by-domain technical analysis of what the Claude Certified Architect exam tests, with a 12-week study roadmap.",
       "chunks": [
-        "Domain 1 — Agentic System Design (32% of exam): covers multi-agent orchestration, tool chaining, memory architecture, and agent lifecycle management. This is the largest domain because Anthropic is positioning Claude as an agentic platform — they want architects who understand what that means in production.",
-        "Domain 2 — Tool Use and Integration (23%): covers MCP server design, tool schema definition, error handling in tool loops, and permission models for tool access. Tests whether you can build agents that interact with real systems reliably.",
-        "Domain 3 — Safety and Reliability (20%): covers Constitutional AI principles in practice, output filtering, human-in-the-loop checkpoint design, and behavioral constraints for production deployments.",
-        "12-week study roadmap: Weeks 1-4 on agentic system design patterns using the Anthropic cookbook; Weeks 5-7 on tool integration with hands-on MCP server builds; Weeks 8-9 on safety engineering; Weeks 10-11 on evaluation and monitoring; Week 12 on practice scenarios and gap review."
+        "Domain 1 — Agentic System Design (32%): covers multi-agent orchestration, tool chaining, memory architecture, and agent lifecycle management.",
+        "Domain 2 — Tool Use and Integration (23%): covers MCP server design, tool schema definition, error handling in tool loops, and permission models for tool access.",
+        "12-week study roadmap: Weeks 1-4 on agentic system design; Weeks 5-7 on tool integration with hands-on MCP server builds; Weeks 8-9 on safety engineering; Weeks 10-11 on evaluation and monitoring; Week 12 on practice scenarios."
       ]
     },
     {
@@ -129,10 +121,9 @@
       "date": "Mar 2026",
       "excerpt": "Anthropic is the first frontier AI lab to launch a professional certification — a market maturity signal that mirrors what AWS Solutions Architect did for cloud.",
       "chunks": [
-        "Every major platform shift follows the same pattern: early adopters build, enterprises evaluate, the vendor launches a certification to formalize expertise, and the certification becomes a hiring filter. AWS launched Solutions Architect in 2013. By 2016, it was table stakes for cloud architect roles. Anthropic just did the same for AI architecture.",
-        "The Claude Certified Architect signals something important about market maturity: Anthropic believes the AI architecture market is large enough — and the demand for certified professionals acute enough — to justify investing in certification infrastructure. This is not a confidence signal about today's market. It is a bet on 2027 and 2028.",
-        "For enterprise AI teams, the certification creates a common vocabulary and a baseline competency standard. For individual architects, it creates differentiation in a market where 'AI experience' is becoming table stakes but 'production-grade agentic system design' is still rare.",
-        "The parallel to AWS SA is not superficial. Within 18 months of the AWS SA launch, it became the fastest-growing technical certification in history. The market for certified cloud architects ballooned. The same dynamic is likely to play out in AI architecture — and the window to be an early certified architect is short."
+        "Every major platform shift follows the same pattern: early adopters build, enterprises evaluate, the vendor launches a certification, and the certification becomes a hiring filter. AWS launched Solutions Architect in 2013. By 2016 it was table stakes for cloud architect roles. Anthropic just did the same for AI architecture.",
+        "The Claude Certified Architect signals that Anthropic believes the AI architecture market is large enough — and the demand for certified professionals acute enough — to justify certification infrastructure.",
+        "For enterprise AI teams, the certification creates a common vocabulary and baseline competency standard. For individual architects, it creates differentiation in a market where production-grade agentic system design is still rare."
       ]
     },
     {
@@ -144,10 +135,9 @@
       "date": "Mar 2026",
       "excerpt": "The traditional developer portfolio is dead. AI can generate CRUD apps in minutes. Here's the new portfolio playbook for developers entering the AI era.",
       "chunks": [
-        "The traditional developer portfolio — a personal website showcasing CRUD apps and weather dashboards — is functionally dead. AI can generate those projects in minutes, which means they prove nothing about your engineering judgment. Hiring managers at AI-native companies are looking for a different signal: can you build with AI, not just build things?",
-        "An AIfolio is 3-5 deployed projects that demonstrate you can architect AI systems: RAG pipelines with real retrieval quality metrics, multi-agent systems with meaningful coordination logic, MCP integrations that solve actual workflow problems, and persistent memory systems using tools like Mem0.",
-        "The gap between AI demos and AIfolio projects is evaluation rigor. A demo shows it works once. An AIfolio project shows you measured how well it works, where it fails, and how you improved it. Hiring managers from Formlabs, Runway Labs, and Polymarket consistently cite evaluation discipline as the differentiator.",
-        "The AIfolio playbook: pick one production-grade problem, build it with current tools, measure it with proper evals, write up what you learned, and deploy it publicly. One project done deeply beats five projects done shallowly."
+        "The traditional developer portfolio — showcasing CRUD apps and weather dashboards — is functionally dead. AI can generate those projects in minutes. Hiring managers at AI-native companies are looking for a different signal: can you build with AI, not just build things?",
+        "An AIfolio is 3-5 deployed projects demonstrating you can architect AI systems: RAG pipelines with real retrieval quality metrics, multi-agent systems with meaningful coordination logic, MCP integrations that solve actual workflow problems.",
+        "The gap between AI demos and AIfolio projects is evaluation rigor. A demo shows it works once. An AIfolio project shows you measured how well it works, where it fails, and how you improved it."
       ]
     },
     {
@@ -159,10 +149,9 @@
       "date": "Mar 2026",
       "excerpt": "Claude Code users approve 93% of permission prompts without reading them. Auto mode replaces rubber-stamping with a two-stage classifier.",
       "chunks": [
-        "Claude Code users approve 93% of permission prompts, which means they have stopped reading them. The human oversight that permission prompts were designed to provide had been replaced by reflexive approval — permission theater rather than permission control. Auto mode was designed to fix this.",
-        "Auto mode uses a two-stage classifier: a fast paranoid filter that catches 8.5% of actions as potentially dangerous, followed by chain-of-thought reasoning that drops false positives to 0.4%. The result is 83% of genuinely dangerous actions caught with zero interruptions for routine operations.",
-        "The permission paradox is a general pattern in human-AI collaboration: oversight mechanisms designed to keep humans in the loop can become so frequent that they train humans to ignore them. The solution is not more prompts — it is smarter filtering that reserves human attention for decisions that actually require it.",
-        "This has direct implications for enterprise agentic AI governance: interrupt humans rarely, but interrupt them well. The HITL checkpoints that matter are the ones where human judgment adds signal that the agent cannot provide itself."
+        "Claude Code users approve 93% of permission prompts, meaning they have stopped reading them. Permission theater replaced permission control. Auto mode fixes this with a two-stage classifier: a fast paranoid filter catching 8.5% of actions, then chain-of-thought reasoning dropping false positives to 0.4%.",
+        "The permission paradox is a general pattern in human-AI collaboration: oversight mechanisms designed to keep humans in the loop train humans to ignore them when too frequent.",
+        "Enterprise implication: interrupt humans rarely, but interrupt them well. HITL checkpoints that matter are the ones where human judgment adds signal the agent cannot provide itself."
       ]
     },
     {
@@ -174,10 +163,9 @@
       "date": "Mar 2026",
       "excerpt": "Anthropic's three-agent harness (Planner/Generator/Evaluator) demonstrates that the gap between coding agent correctness and enterprise deployability is a governance gap.",
       "chunks": [
-        "Anthropic's three-agent harness uses a GAN-inspired loop: a Planner decomposes the problem, a Generator produces solutions, and an Evaluator scores them against explicit criteria. The Evaluator's output feeds back into the Planner. This is not just better model architecture — it is governance architecture baked into the agent loop itself.",
-        "The event featured Robert Brennan (CEO, OpenHands) and Nick Arcolano (Head of Research, Jellyfish) exploring how autonomous AI agents are redefining software development. The consensus: coding agent correctness is a solved problem at narrow scope. Enterprise deployability is not.",
-        "The gap between what is technically possible with agentic AI and what is responsibly deployable in enterprise environments is where the hardest work happens. Audit trails, accountability chains, and human override mechanisms are not product features — they are architectural requirements for regulated industries.",
-        "Governance harnesses are not constraints on agent capability. They are the infrastructure that makes agent capability usable in environments where consequences matter. The enterprises that build governance harnesses first will deploy agents faster — not slower."
+        "Anthropic's three-agent harness uses a GAN-inspired loop: a Planner decomposes the problem, a Generator produces solutions, and an Evaluator scores them against explicit criteria. This is governance architecture baked into the agent loop itself.",
+        "The gap between what is technically possible with agentic AI and what is responsibly deployable in enterprise environments is where the hardest work happens. Audit trails, accountability chains, and human override mechanisms are architectural requirements for regulated industries.",
+        "Governance harnesses are not constraints on agent capability. They are the infrastructure that makes agent capability usable in environments where consequences matter."
       ]
     },
     {
@@ -187,11 +175,11 @@
       "source": "substack",
       "tags": ["Newsletter", "AI Career", "Job Market"],
       "date": "Mar 2026",
-      "excerpt": "Stop applying on LinkedIn. Here's where AI Engineers are actually getting hired in 2026 — salary ranges, industry breakdown, and where to look.",
+      "excerpt": "Stop applying on LinkedIn. Here's where AI Engineers are actually getting hired in 2026 — salary ranges and industry breakdown.",
       "chunks": [
-        "AI Engineer salaries by industry in 2026: Tech and SaaS average $167K, Media $191K, Finance $180K-$400K+, Healthcare $147K, Consulting $157K, Startups $120K-$180K plus equity. The highest compensation is in finance and media, not big tech — a shift from the previous decade's patterns.",
-        "The jobs are not where most people are looking. LinkedIn is oversaturated. The signal-to-noise ratio on traditional job boards is collapsing. Where AI Engineers are actually getting hired: company engineering blogs, AI-specific job boards, founder networks, and direct outreach to teams shipping products you use.",
-        "Three categories of AI Engineer roles in 2026: builders who design and implement AI systems end-to-end, integrators who connect AI capabilities to existing enterprise workflows, and evaluators who build the measurement infrastructure that tells you whether your AI system is actually working."
+        "AI Engineer salaries by industry in 2026: Tech and SaaS $167K, Media $191K, Finance $180K-$400K+, Healthcare $147K, Consulting $157K, Startups $120K-$180K plus equity.",
+        "The jobs are not where most people are looking. LinkedIn is oversaturated. AI Engineers are actually getting hired via company engineering blogs, AI-specific job boards, founder networks, and direct outreach.",
+        "Three categories of AI Engineer roles: builders who design and implement AI systems end-to-end, integrators who connect AI to enterprise workflows, and evaluators who build measurement infrastructure."
       ]
     },
     {
@@ -203,10 +191,9 @@
       "date": "Mar 2026",
       "excerpt": "The 6-phase Claude Code startup sequence: authentication, CLAUDE.md sweep, memory loading, tool registration, system prompt assembly, and the agentic loop.",
       "chunks": [
-        "Claude Code executes six phases on startup: authentication check against stored credentials, CLAUDE.md configuration sweep through directory hierarchy, memory loading from MEMORY.md (first 200 lines), tool and MCP server registration, system prompt assembly (6K-18K tokens depending on context), and initialization of the agentic loop.",
-        "The system prompt assembly phase is where most of the cost is. A fully loaded Claude Code session with multiple CLAUDE.md files, loaded memory, and registered MCP servers can assemble a system prompt of 15K-18K tokens before you type a single character. At Sonnet pricing, this is approximately $0.05-0.09 per session start.",
-        "The CLAUDE.md sweep is hierarchical: Claude Code reads from the current directory up to the git root and then to the user's home directory. Lower files override higher files on key conflicts. This gives you project-level, workspace-level, and user-level configuration with clear precedence rules.",
-        "Understanding the startup sequence matters for cost optimization: keep MEMORY.md under 200 lines (everything after is truncated anyway), minimize CLAUDE.md inheritance chains, and register only the MCP servers you actually use in a given session."
+        "Claude Code executes six phases on startup: authentication, CLAUDE.md configuration sweep through directory hierarchy, memory loading from MEMORY.md (first 200 lines), tool and MCP server registration, system prompt assembly (6K-18K tokens), and initialization of the agentic loop.",
+        "The CLAUDE.md sweep is hierarchical: Claude Code reads from the current directory up to the git root and then to the user's home directory. Lower files override higher files on key conflicts.",
+        "Understanding the startup sequence matters for cost optimization: keep MEMORY.md under 200 lines, minimize CLAUDE.md inheritance chains, and register only the MCP servers you actually use."
       ]
     },
     {
@@ -218,9 +205,160 @@
       "date": "Mar 2026",
       "excerpt": "AI Engineer is the #1 fastest-growing job of 2026. Here's what it actually means and how to become one.",
       "chunks": [
-        "AI Engineer is not Data Scientist, not ML Engineer, not Software Engineer with an AI sprinkle. The role sits at the intersection of systems design and applied AI: you build production systems that use AI capabilities, you evaluate whether those systems work, and you iterate on them based on real usage data.",
-        "The fastest path to AI Engineer from different starting points: Software Engineers should build one end-to-end RAG system and one multi-agent workflow, then measure both rigorously. Data Scientists should learn to deploy models as APIs and build evaluation pipelines. Career switchers should focus on the LLM application layer — RAG, agents, evals — not on model training.",
-        "Five self-assessment questions to know if you are ready to call yourself an AI Engineer: Can you build a RAG pipeline from scratch? Can you write evals for an LLM output? Can you deploy a model as an API? Can you debug a multi-agent workflow? Can you explain why your AI system fails on specific inputs?"
+        "AI Engineer sits at the intersection of systems design and applied AI: you build production systems that use AI capabilities, evaluate whether those systems work, and iterate based on real usage data.",
+        "Fastest path by background: Software Engineers should build one end-to-end RAG system and one multi-agent workflow. Data Scientists should learn to deploy models as APIs and build evaluation pipelines.",
+        "Five self-assessment questions: Can you build a RAG pipeline from scratch? Can you write evals for an LLM output? Can you deploy a model as an API? Can you debug a multi-agent workflow? Can you explain why your AI system fails on specific inputs?"
+      ]
+    },
+    {
+      "id": "talk-msft-ecosystem",
+      "title": "From AI Pilots to Enterprise Intelligence: Microsoft Agentic Ecosystem Workshop",
+      "url": "https://www.linkedin.com/posts/kranthimanchikanti_agenticai-enterpriseai-aigovernance-activity-7443313880149327872-6Vxa",
+      "source": "talk",
+      "tags": ["Workshop", "Agentic AI", "Enterprise AI"],
+      "date": "Mar 2026",
+      "excerpt": "Co-hosted a 5-hour strategy session at Microsoft Burlington, MA with 40+ CIOs, CTOs, and AI transformation leaders on moving from AI pilots to agent-operated workflows.",
+      "chunks": [
+        "Co-hosted and presented at the Microsoft Agentic Ecosystem Workshop at Microsoft's Burlington, MA campus — an immersive, hands-on strategy session designed to help enterprises move beyond fragmented AI experiments and toward a structured Intelligence Layer.",
+        "Worked directly with 40+ senior leaders — CIOs, CTOs, and AI transformation leaders — spanning manufacturing, high tech, telecom, healthcare, and financial services. The central question: How do we move from isolated AI pilots to agent-operated workflows responsibly, at scale, and with measurable business value?",
+        "The governance conversations were most energizing: in regulated industries the questions are about audit trails, accountability chains, and maintaining human oversight when agents start making consequential decisions."
+      ]
+    },
+    {
+      "id": "talk-aitinkerers",
+      "title": "GPT-RAG: Semantic Kernel Load Testing",
+      "url": "https://boston.aitinkerers.org/talks/rsvp_1fsFWgcFzFY",
+      "source": "talk",
+      "tags": ["Talk", "RAG", "Semantic Kernel"],
+      "date": "2025",
+      "excerpt": "Talk at AI Tinkerers Boston on load testing enterprise RAG systems built with Semantic Kernel.",
+      "chunks": [
+        "Presented at AI Tinkerers Boston on load testing GPT-RAG systems built with Semantic Kernel — covering throughput benchmarking, latency profiling, and failure mode identification at scale.",
+        "GPT-RAG is an enterprise retrieval-augmented generation architecture. Load testing surfaces the bottlenecks that only appear under production traffic: vector search latency, reranker throughput, and LLM token rate limits."
+      ]
+    },
+    {
+      "id": "talk-mlads",
+      "title": "ML & Data Science Presenter",
+      "url": "https://www.linkedin.com/feed/update/urn:li:activity:7212158420643102720/",
+      "source": "talk",
+      "tags": ["Talk", "Machine Learning", "Data Science"],
+      "date": "Jun 2024",
+      "excerpt": "Presenter at MLADS — Microsoft's internal Machine Learning and Data Science conference.",
+      "chunks": [
+        "Presented at MLADS (Machine Learning and Data Science) — Microsoft's internal conference for ML practitioners and researchers. Shared applied research and production learnings on AI systems design."
+      ]
+    },
+    {
+      "id": "talk-chain-verification",
+      "title": "Chain of Verification Agent",
+      "url": "",
+      "source": "talk",
+      "tags": ["Poster", "AI Agents", "Research"],
+      "date": "2024",
+      "excerpt": "Poster presentation at Amazon Foundation Model Science Symposium on Chain of Verification agent architecture for reducing hallucinations.",
+      "chunks": [
+        "Poster presentation at the Amazon Foundation Model Science Symposium on the Chain of Verification agent — an architecture that reduces hallucinations by having an agent verify its own outputs through a structured self-critique loop before returning results."
+      ]
+    },
+    {
+      "id": "talk-hitl",
+      "title": "Building Human-in-the-Loop AI Workflows with Microsoft Agent Framework",
+      "url": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/building-human-in-the-loop-ai-workflows-with-microsoft-agent-framework/4460342",
+      "source": "talk",
+      "tags": ["Talk", "HITL", "Agentic AI"],
+      "date": "2025",
+      "excerpt": "Published on Microsoft Tech Community — designing human oversight checkpoints in agentic AI workflows.",
+      "chunks": [
+        "Building Human-in-the-Loop AI Workflows with Microsoft Agent Framework — covers the design patterns for human oversight checkpoints, escalation logic, and quality validation architectures in production agentic systems.",
+        "HITL design is not about interrupting agents constantly — it is about interrupting them at the right moments. The patterns that work identify irreversible actions, low-confidence decision points, and domain-specific risk thresholds."
+      ]
+    },
+    {
+      "id": "talk-rag-evals",
+      "title": "Evaluations in RAG",
+      "url": "https://www.linkedin.com/feed/update/urn:li:activity:7200964669820256256/",
+      "source": "talk",
+      "tags": ["Talk", "RAG", "Evaluation"],
+      "date": "2024",
+      "excerpt": "Community talk on evaluation frameworks for RAG systems — RAGAs, faithfulness, context precision, and answer relevance metrics.",
+      "chunks": [
+        "Community talk on evaluations in RAG: covering RAGAs framework metrics — faithfulness, context precision, context recall, and answer relevance — and how to build automated eval pipelines that catch retrieval and generation failures before they reach users."
+      ]
+    },
+    {
+      "id": "talk-ai-software",
+      "title": "AI in Software Development",
+      "url": "https://www.youtube.com/watch?v=NBgn4b8B1l0",
+      "source": "talk",
+      "tags": ["Talk", "AI Development", "DevOps"],
+      "date": "2024",
+      "excerpt": "Talk at DevOps Summit Canada on integrating AI into software development workflows — code generation, review automation, and test generation.",
+      "chunks": [
+        "Talk at DevOps Summit Canada on AI in software development — covering code generation tools, AI-assisted code review, automated test generation, and the impact on developer productivity and software quality at enterprise scale."
+      ]
+    },
+    {
+      "id": "project-agentshift",
+      "title": "AgentShift — Convert AI Agents Between Frameworks",
+      "url": "https://github.com/ogkranthi/agentshift",
+      "source": "project",
+      "tags": ["Open Source", "AI Agents", "Framework Converter"],
+      "date": "2026",
+      "excerpt": "Convert AI agents between platforms. Define once, run anywhere. Universal framework converter — pip install agentshift.",
+      "chunks": [
+        "AgentShift converts AI agents between frameworks — OpenClaw, Claude Code, Microsoft Copilot, AWS Bedrock, Vertex AI, LangGraph, CrewAI. Define once, run anywhere. Three-stage pipeline: parse agent definition → intermediate representation → emit platform-specific config.",
+        "Install with pip install agentshift. Adding new platforms only requires writing a new parser or emitter, without touching core logic. MIT licensed, fully open source."
+      ]
+    },
+    {
+      "id": "project-peergraph",
+      "title": "PeerGraph — AI Research to Product Graph",
+      "url": "https://www.peergraph.ai/",
+      "source": "project",
+      "tags": ["Open Source", "AI Research", "Graph"],
+      "date": "2026",
+      "excerpt": "Open graph connecting AI researchers with product builders. 144+ researchers, 90+ builders, 216 research-to-product connections. Applied Impact Index.",
+      "chunks": [
+        "PeerGraph visualizes how academic AI research translates into real-world applications — mapping who's publishing, who's building, and how research flows into products. Covers 144+ researchers, 90+ builders, and 216 research-to-product connections across 50+ AI domains.",
+        "Introduces the Applied Impact Index — a metric measuring real-world adoption beyond citation counts. MIT licensed, free, no login required."
+      ]
+    },
+    {
+      "id": "project-cogcontrol",
+      "title": "CogControl-Stakes: Metacognition Benchmark",
+      "url": "https://www.kaggle.com/benchmarks/ogkranthi22/cogcontrol-stakes-metacognition",
+      "source": "project",
+      "tags": ["Research", "Benchmark", "Metacognition"],
+      "date": "2026",
+      "excerpt": "Behavioral benchmark for measuring LLM metacognitive monitoring and control — grounded in Nelson & Narens (1990). Submitted to Google DeepMind's AGI progress challenge.",
+      "chunks": [
+        "CogControl-Stakes measures LLM metacognitive monitoring and control — grounded in Nelson & Narens (1990) framework. Wagering paradigm for calibration, asymmetric-payoff abstention under stakes.",
+        "Submitted to Google DeepMind's AGI progress evaluation challenge. Evaluated on Gemini 2.5 Flash: systematic overconfidence (ECE 0.21) and catastrophic metacognitive control failure in specialist-required domains."
+      ]
+    },
+    {
+      "id": "project-gpt-rag",
+      "title": "GPT-RAG — Enterprise RAG Architecture",
+      "url": "https://github.com/Azure/gpt-rag",
+      "source": "project",
+      "tags": ["Open Source", "RAG", "Enterprise AI"],
+      "date": "2024",
+      "excerpt": "Retrieval-augmented generation architecture for enterprise AI on Azure — contributed to core design.",
+      "chunks": [
+        "GPT-RAG is Microsoft Azure's enterprise RAG architecture — a production-grade retrieval-augmented generation system for enterprise AI. Contributed to core design including orchestration patterns and evaluation frameworks."
+      ]
+    },
+    {
+      "id": "project-sagemaker-clarify",
+      "title": "SageMaker Clarify — AI Fairness and Explainability",
+      "url": "https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-foundation-model-evaluate.html",
+      "source": "project",
+      "tags": ["Open Source", "AI Safety", "Explainability"],
+      "date": "2024",
+      "excerpt": "Contributed to AI fairness and explainability tooling for foundation model evaluation in Amazon SageMaker.",
+      "chunks": [
+        "SageMaker Clarify provides AI fairness and explainability tooling for foundation model evaluation — contributed to the framework for bias detection, feature attribution, and model explainability at enterprise scale."
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Search icon added to nav (top right) — opens full-screen overlay on click or Cmd/Ctrl+K
- Overlay: large centered input, blurred backdrop, slide-in animation, Escape to close
- Index expanded to cover everything: 9 articles, 7 Substack posts, 9 talks, 7 projects (32 total entries)
- Result badges: Article (indigo), Substack (orange), Talk (green), Project (dark navy)
- Highlights matching terms in yellow, shows best-matching passage per result, top 7 results