### PR TITLE
fix: remove extra closing div breaking page layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,7 @@ footer p {
       </div>
   </article>
 
-  </div></div>
+  </div>
 
 <!-- NEWSLETTER -->
 <section class="subscribe reveal">


### PR DESCRIPTION
Extra </div> on line 1757 left over from old #all-writing wrapper — caused the entire page structure to collapse.